### PR TITLE
Added AccountNode model

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Models marked with an asterix are pure CRUD models
   - [x] Account
     - [ ] Account Balance
     - [x] Account Category *
-    - [ ] Account Note *
+    - [x] Account Note *
     - [ ] Account Note Attachment
     - [ ] Account Opening Balance *
     - [ ] Account Payment *

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -212,7 +212,7 @@ abstract class BaseModel
         }
 
         // TODO Submission Body and Validation
-        $this->request->request('POST', $this->endpoint, 'Save');
+        return $this->request->request('POST', $this->endpoint, 'Save');
     }
 
     /**

--- a/src/Models/AccountNote.php
+++ b/src/Models/AccountNote.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * SageOne Library
+ *
+ * @category Library
+ * @package  SageOne
+ * @author   Darryn Ten <darrynten@github.com>
+ * @license  MIT <https://github.com/darrynten/sage-one-php/blob/master/LICENSE>
+ * @link     https://github.com/darrynten/sage-one-php
+ */
+
+namespace DarrynTen\SageOne\Models;
+
+use DarrynTen\SageOne\BaseModel;
+
+/**
+ * Account Note Model
+ *
+ * Details on writable properties for Account Note:
+ * https://accounting.sageone.co.za/api/1.1.2/Help/ResourceModel?modelName=AccountNote
+ */
+class AccountNote extends BaseModel
+{
+    /**
+     * The ID of the account note
+     *
+     * @var int $id
+     */
+    protected $id;
+
+    /**
+     * User id of the account note
+     *
+     * Nullable
+     *
+     * @var int $userId
+     */
+    protected $userId = null;
+
+    /**
+     * Account id of the account note
+     *
+     * @var int $accountId
+     */
+    protected $accountId;
+
+    /**
+     * Subject
+     *
+     * @var string $subject
+     */
+    protected $subject;
+
+    /**
+     * Entry date
+     *
+     * Nullable
+     *
+     * @var DateTime $entryDate
+     */
+    protected $entryDate = null;
+
+    /**
+     * Action date
+     *
+     * @var DateTime $actionDate
+     */
+    protected $actionDate;
+
+    /**
+     * Status
+     *
+     * Nullable
+     *
+     * @var bool $status
+     */
+    protected $status = null;
+
+    /**
+     * Note
+     *
+     * @var string $note
+     */
+    protected $note;
+
+    /**
+     * Has attachments
+     *
+     * Nullable
+     *
+     * @var bool $hasAttachments
+     */
+    protected $hasAttachments = null;
+
+    /**
+     * The API Endpoint
+     *
+     * @var string $endpoint
+     */
+    protected $endpoint = 'AccountNote';
+
+    /**
+     * @var array $fields
+     */
+    protected $fields = [
+        'id' => [
+            'type' => 'integer',
+            'nullable' => false,
+            'persistable' => true,
+        ],
+        'accountId' => [
+            'type' => 'integer',
+            'nullable' => false,
+            'persistable' => true,
+        ],
+        'userId' => [
+            'type' => 'integer',
+            'nullable' => true,
+            'persistable' => true,
+        ],
+        'subject' => [
+            'type' => 'string',
+            'nullable' => false,
+            'persistable' => true,
+        ],
+        'entryDate' => [
+            'type' => 'DateTime',
+            'nullable' => true,
+            'persistable' => true,
+        ],
+        'actionDate' => [
+            'type' => 'DateTime',
+            'nullable' => false,
+            'persistable' => true,
+        ],
+        'status' => [
+            'type' => 'boolean',
+            'nullable' => true,
+            'persistable' => true,
+        ],
+        'note' => [
+            'type' => 'string',
+            'nullable' => false,
+            'persistable' => true,
+        ],
+        'hasAttachments' => [
+            'type' => 'boolean',
+            'nullable' => true,
+            'persistable' => true,
+        ]
+    ];
+
+    /**
+     * @var array $features
+     */
+    protected $features = [
+        'all' => true,
+        'get' => true,
+        'save' => true,
+        'delete' => true,
+    ];
+}

--- a/tests/SageOne/Models/AccountNoteModelTest.php
+++ b/tests/SageOne/Models/AccountNoteModelTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace DarrynTen\SageOne\Tests\SageOne\Models;
+
+use DarrynTen\SageOne\Models\AccountNote;
+use DarrynTen\SageOne\Request\RequestHandler;
+use GuzzleHttp\Client;
+use ReflectionClass;
+
+use DarrynTen\SageOne\Exception\ModelException;
+
+class AccountNoteModelTest extends BaseModelTest
+{
+    public function testInstanceOf()
+    {
+        $this->verifyInstanceOf(AccountNote::class);
+    }
+
+    public function testSetUndefined()
+    {
+        $this->verifySetUndefined(AccountNote::class);
+    }
+
+    public function testGetUndefined()
+    {
+        $this->verifyGetUndefined(AccountNote::class);
+    }
+
+    public function testCanNotNullify()
+    {
+        $this->verifyCanNotNullify(AccountNote::class, 'accountId');
+    }
+
+    public function testCanNullify()
+    {
+        $this->verifyCanNullify(AccountNote::class, 'userId');
+    }
+
+    public function testBadImport()
+    {
+        $this->verifyBadImport(AccountNote::class, 'accountId');
+    }
+
+    public function testInject()
+    {
+        $this->verifyInject(AccountNote::class, function($model, $data) {
+            $this->assertEquals($model->id, 2);
+            $this->assertEquals($model->userId, 1);
+            $this->assertEquals($model->accountId, 1);
+            $this->assertEquals($model->subject, 'sample string 3');
+            $this->assertEquals($model->entryDate->format('Y-m-d'), '2017-07-01');
+            $this->assertEquals($model->actionDate->format('Y-m-d'), '2017-07-01');
+            $this->assertTrue($model->status);
+            $this->assertEquals($model->note, 'sample string 4');
+            $this->assertTrue($model->hasAttachments);
+
+            $objArray = json_decode($model->toJson(), true);
+            $this->assertCount(9, $objArray);
+        });
+    }
+
+    public function testAttributes()
+    {
+        $this->verifyAttributes(AccountNote::class, [
+            'id' => [
+                'type' => 'integer', 'persistable' => true
+            ],
+            'userId' => [
+                'type' => 'integer', 'nullable' => true, 'persistable' => true
+            ],
+            'accountId' => [
+                'type' => 'integer', 'persistable' => true
+            ],
+            'subject' => [
+                'type' => 'string', 'persistable' => true
+            ],
+            'entryDate' => [
+                'type' => 'DateTime', 'nullable' => true, 'persistable' => true
+            ],
+            'actionDate' => [
+                'type' => 'DateTime', 'persistable' => true
+            ],
+            'status' => [
+                'type' => 'boolean', 'nullable' => true, 'persistable' => true
+            ],
+            'note' => [
+                'type' => 'string', 'persistable' => true
+            ],
+            'hasAttachments' => [
+                'type' => 'boolean', 'nullable' => true, 'persistable' => true
+            ]
+        ]);
+    }
+
+    public function testFeatures()
+    {
+        $this->verifyFeatures(AccountNote::class, [
+            'all' => true, 'get' => true, 'delete' => true, 'save' => true
+        ]);
+    }
+
+    public function testGetAll()
+    {
+        $this->verifyGetAll(AccountNote::class, function($results, $data) {
+            $this->assertEquals(2, count($results));
+            $this->assertEquals(1, $results[0]['AccountId']);
+            $this->assertEquals(1, $results[0]['UserId']);
+            $this->assertEquals(2, $results[0]['ID']);
+            $this->assertEquals('sample string 3', $results[0]['Subject']);
+            $this->assertEquals('2017-07-01', $results[0]['EntryDate']);
+            $this->assertEquals('2017-07-01', $results[0]['ActionDate']);
+            $this->assertTrue($results[0]['Status']);
+            $this->assertEquals('sample string 4', $results[0]['Note']);
+            $this->assertTrue($results[0]['HasAttachments']);
+            $this->assertCount(9, $results[0]);
+            $this->assertCount(9, $results[1]);
+        });
+    }
+
+    public function testGetId()
+    {
+        $this->verifyGetId(AccountNote::class, 2, function($model) {
+            $this->assertEquals(2, $model->id);
+            $this->assertEquals(1, $model->accountId);
+            $this->assertEquals(1, $model->userId);
+            $this->assertEquals('sample string 3', $model->subject);
+            $this->assertEquals('2017-07-01', $model->entryDate->format('Y-m-d'));
+            $this->assertEquals('2017-07-01', $model->actionDate->format('Y-m-d'));
+            $this->assertTrue($model->status);
+            $this->assertEquals('sample string 4', $model->note);
+            $this->assertTrue($model->hasAttachments);
+        });
+    }
+
+    public function testSave()
+    {
+        $this->verifySave(AccountNote::class, function($response) {
+            $this->assertEquals(2, $response->ID);
+            // TODO Do actual checks
+        });
+    }
+
+    public function testDelete()
+    {
+        $this->verifyDelete(AccountNote::class, 11, function() {
+            // TODO do actual checks
+        });
+    }
+}

--- a/tests/SageOne/Models/AccountNoteModelTest.php
+++ b/tests/SageOne/Models/AccountNoteModelTest.php
@@ -43,7 +43,7 @@ class AccountNoteModelTest extends BaseModelTest
 
     public function testInject()
     {
-        $this->verifyInject(AccountNote::class, function($model, $data) {
+        $this->verifyInject(AccountNote::class, function ($model, $data) {
             $this->assertEquals($model->id, 2);
             $this->assertEquals($model->userId, 1);
             $this->assertEquals($model->accountId, 1);
@@ -101,7 +101,7 @@ class AccountNoteModelTest extends BaseModelTest
 
     public function testGetAll()
     {
-        $this->verifyGetAll(AccountNote::class, function($results, $data) {
+        $this->verifyGetAll(AccountNote::class, function ($results, $data) {
             $this->assertEquals(2, count($results));
             $this->assertEquals(1, $results[0]['AccountId']);
             $this->assertEquals(1, $results[0]['UserId']);
@@ -119,7 +119,7 @@ class AccountNoteModelTest extends BaseModelTest
 
     public function testGetId()
     {
-        $this->verifyGetId(AccountNote::class, 2, function($model) {
+        $this->verifyGetId(AccountNote::class, 2, function ($model) {
             $this->assertEquals(2, $model->id);
             $this->assertEquals(1, $model->accountId);
             $this->assertEquals(1, $model->userId);
@@ -134,7 +134,7 @@ class AccountNoteModelTest extends BaseModelTest
 
     public function testSave()
     {
-        $this->verifySave(AccountNote::class, function($response) {
+        $this->verifySave(AccountNote::class, function ($response) {
             $this->assertEquals(2, $response->ID);
             // TODO Do actual checks
         });
@@ -142,7 +142,7 @@ class AccountNoteModelTest extends BaseModelTest
 
     public function testDelete()
     {
-        $this->verifyDelete(AccountNote::class, 11, function() {
+        $this->verifyDelete(AccountNote::class, 11, function () {
             // TODO do actual checks
         });
     }

--- a/tests/SageOne/Models/BaseModelTest.php
+++ b/tests/SageOne/Models/BaseModelTest.php
@@ -118,7 +118,6 @@ abstract class BaseModelTest extends \PHPUnit_Framework_TestCase
         $obj = new \stdClass;
         $obj->ID = 1;
         $model->loadResult($obj);
-
     }
 
     protected function verifyAttributes(string $class, array $attributes)

--- a/tests/SageOne/Models/BaseModelTest.php
+++ b/tests/SageOne/Models/BaseModelTest.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace DarrynTen\SageOne\Tests\SageOne\Models;
+
+use DarrynTen\SageOne\Request\RequestHandler;
+use InterNations\Component\HttpMock\PHPUnit\HttpMockTrait;
+use GuzzleHttp\Client;
+use ReflectionClass;
+
+use DarrynTen\SageOne\Exception\ModelException;
+
+abstract class BaseModelTest extends \PHPUnit_Framework_TestCase
+{
+    use HttpMockTrait;
+
+    protected $config = [
+        'username' => 'username',
+        'password' => 'password',
+        'key' => 'key',
+        'endpoint' => '//localhost:8082',
+        'version' => '1.1.2',
+        'companyId' => null
+    ];
+
+    public static function setUpBeforeClass()
+    {
+        static::setUpHttpMockBeforeClass('8082', 'localhost');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        static::tearDownHttpMockAfterClass();
+    }
+
+    public function setUp()
+    {
+        $this->setUpHttpMock();
+    }
+
+    public function tearDown()
+    {
+        $this->tearDownHttpMock();
+    }
+
+    /**
+     * Extracts className from path A\B\C\ClassName
+     *
+     * @param string $classPath Full path to the class
+     */
+    private function getClassName(string $class)
+    {
+        $classPath = explode('\\', $class);
+        $className = $classPath[ count($classPath) - 1];
+        return $className;
+    }
+
+    protected function verifyInstanceOf(string $class)
+    {
+        $request = new $class($this->config);
+        $this->assertInstanceOf($class, $request);
+    }
+
+    protected function verifySetUndefined(string $class)
+    {
+        $className = $this->getClassName($class);
+
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('Model "' . $className . '" key doesNotExist value xyz Attempting to set a property that is not defined in the model');
+        $this->expectExceptionCode(10113);
+
+        $model = new $class($this->config);
+        $model->doesNotExist = 'xyz';
+    }
+
+    protected function verifyGetUndefined(string $class)
+    {
+        $className = $this->getClassName($class);
+
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('Model "' . $className . '" key doesNotExist Attempting to get an undefined property');
+        $this->expectExceptionCode(10116);
+
+        $model = new $class($this->config);
+        $throw = $model->doesNotExist;
+    }
+
+    protected function verifyCanNotNullify(string $class, string $key)
+    {
+        $className = $this->getClassName($class);
+
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('Model "' . $className . '" attempting to nullify key ' . $key . ' Property is null without nullable permission');
+        $this->expectExceptionCode(10111);
+
+        $model = new $class($this->config);
+        $model->{$key} = null;
+    }
+
+    protected function verifyCanNullify(string $class, string $key)
+    {
+        $className = $this->getClassName($class);
+
+        $model = new $class($this->config);
+        $model->{$key} = null;
+        $this->assertNull($model->{$key});
+    }
+
+    protected function verifyBadImport(string $class, string $key)
+    {
+        $className = $this->getClassName($class);
+
+        $model = new $class($this->config);
+
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('Model "' . $className . '" Defined key "' . $key . '" not present in payload A property is missing in the loadResult payload');
+        $this->expectExceptionCode(10112);
+
+        $obj = new \stdClass;
+        $obj->ID = 1;
+        $model->loadResult($obj);
+
+    }
+
+    protected function verifyAttributes(string $class, array $attributes)
+    {
+        $model = new $class($this->config);
+        $className = $this->getClassName($class);
+
+        foreach ($attributes as $name => $options) {
+            $this->assertObjectHasAttribute($name, $model);
+            if (isset($options['nullable'])) {
+                $this->assertNull($model->{$name}, "Model $className Key $name is not null");
+            }
+        }
+
+        // Fields mapping
+        $reflect = new ReflectionClass($model);
+        $reflectValue = $reflect->getProperty('fields');
+        $reflectValue->setAccessible(true);
+        $value = $reflectValue->getValue(new $class($this->config));
+
+        $fieldsCount = count($attributes);
+
+        $this->assertCount($fieldsCount, $value);
+
+        foreach ($attributes as $name => $options) {
+            $this->assertEquals(true, is_array($value[$name]));
+            $this->assertEquals($options['type'], $value[$name]['type'],
+                "Model $className Key $name Expected type {$options['type']} Got {$value[$name]['type']}");
+            $this->assertEquals('boolean', gettype($value[$name]['nullable']));
+            $this->assertEquals('boolean', gettype($value[$name]['persistable']));
+
+            $nullable = isset($options['nullable']);
+            $nullableText = $nullable ? 'true': 'false';
+            $nullableOptionText = $value[$name]['nullable'] ? 'true' : 'false';
+            $this->assertEquals($nullable, $value[$name]['nullable'],
+                "Model $className Key $name Expected nullable to be {$nullableText} got {$nullableOptionText}");
+
+            $persistable = isset($options['persistable']);
+            $persistableText = $persistable ? 'true' : 'false';
+            $persistableOptionText = $value[$name]['persistable'] ? 'true' : 'false';
+
+            $this->assertEquals($persistable, $value[$name]['persistable'],
+                "Model $className Key $name Expected persistable to be {$persistableText} got {$persistableOptionText}");
+        }
+    }
+
+    protected function verifyFeatures(string $class, array $features)
+    {
+        $model = new $class($this->config);
+        $reflect = new ReflectionClass($model);
+        $className = $this->getClassName($class);
+
+        $reflectValue = $reflect->getProperty('features');
+        $reflectValue->setAccessible(true);
+        $value = $reflectValue->getValue($model);
+        $this->assertArrayHasKey('all', $value);
+        $this->assertArrayHasKey('get', $value);
+        $this->assertArrayHasKey('save', $value);
+        $this->assertArrayHasKey('delete', $value);
+        $this->assertCount(4, $value);
+
+        foreach (['all', 'get', 'save', 'delete'] as $feature) {
+            $expected = $features[$feature] ? 'true' : 'false';
+            $actual = $value[$feature] ? 'true' : 'false';
+            $this->assertEquals($features[$feature], $value[$feature],
+                "Model {$className} Feature {$feature} expected {$expected} got {$actual}");
+        }
+    }
+
+    protected function verifyInject(string $class, callable $whatToCheck)
+    {
+        $className = $this->getClassName($class);
+
+        $model = new $class($this->config);
+        $data = json_decode(file_get_contents(__DIR__ . "/../../mocks/{$className}/GET_{$className}_Get_xx.json"));
+        $model->loadResult($data);
+
+        $whatToCheck($model, $data);
+    }
+
+    protected function verifyGetAll(string $class, callable $whatToCheck)
+    {
+        $className = $this->getClassName($class);
+        $data = file_get_contents(__DIR__ . "/../../mocks/{$className}/GET_{$className}_Get.json");
+
+        $this->http->mock
+            ->when()
+                ->methodIs('GET')
+                ->pathIs("/1.1.2/{$className}/Get?apikey=key")
+            ->then()
+                ->body($data)
+            ->end();
+        $this->http->setUp();
+
+        $request = new RequestHandler($this->config);
+
+        /**
+         * We make a local client to connect to our mock and get the
+         * expected result
+         */
+        $localClient = new Client();
+
+        $localResult = $localClient->request(
+            'GET',
+            "http://localhost:8082/1.1.2/{$className}/Get?apikey=key",
+            []
+        );
+
+        /**
+         * We then make a mock client, and tell the mock client that it
+         * should return what the local client got from the mock
+         */
+        $mockClient = \Mockery::mock(
+            'Client'
+        );
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->andReturn($localResult);
+
+        /**
+         * Insert the mocked client into the request class via reflection
+         *
+         * This will pass the desired mock object back to the assertion
+         * as it replaces the legit Client() object
+         */
+        $reflection = new ReflectionClass($request);
+        $reflectedClient = $reflection->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($request, $mockClient);
+
+        $model = new $class($this->config);
+
+        /**
+         * We then reflect into the model
+         */
+        $modelReflection = new ReflectionClass($model);
+        $reflectedRequest = $modelReflection->getProperty('request');
+        $reflectedRequest->setAccessible(true);
+        $reflectedRequest->setValue($model, $request);
+
+        $allInstances = json_decode($model->all(), true);
+
+        $this->assertEquals(3, count($allInstances));
+        $this->assertArrayHasKey('Results', $allInstances);
+        $this->assertArrayHasKey('ReturnedResults', $allInstances);
+        $this->assertArrayHasKey('TotalResults', $allInstances);
+
+        $whatToCheck($allInstances['Results'], $data);
+    }
+
+    protected function verifyGetId(string $class, int $id, callable $whatToCheck)
+    {
+        $className = $this->getClassName($class);
+        $data = file_get_contents(__DIR__ . "/../../mocks/{$className}/GET_{$className}_Get_xx.json");
+
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs("/1.1.2/{$className}/Get/{$id}?apikey=key")
+            ->then()
+            ->body($data)
+            ->end();
+        $this->http->setUp();
+
+        $request = new RequestHandler($this->config);
+
+        /**
+         * We make a local client to connect to our mock and get the
+         * expected result
+         */
+        $localClient = new Client();
+
+        $localResult = $localClient->request(
+            'GET',
+            "http://localhost:8082/1.1.2/{$className}/Get/{$id}?apikey=key",
+            []
+        );
+
+        /**
+         * We then make a mock client, and tell the mock client that it
+         * should return what the local client got from the mock
+         */
+        $mockClient = \Mockery::mock(
+            'Client'
+        );
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->andReturn($localResult);
+
+        /**
+         * Insert the mocked client into the request class via reflection
+         *
+         * This will pass the desired mock object back to the assertion
+         * as it replaces the legit Client() object
+         */
+        $reflection = new ReflectionClass($request);
+        $reflectedClient = $reflection->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($request, $mockClient);
+
+        $model = new $class($this->config);
+
+        /**
+         * We then reflect into the account model
+         */
+        $modelReflection = new ReflectionClass($model);
+        $reflectedRequest = $modelReflection->getProperty('request');
+        $reflectedRequest->setAccessible(true);
+        $reflectedRequest->setValue($model, $request);
+
+        // Fetch an id
+        $model->get($id);
+
+        $whatToCheck($model);
+    }
+
+    protected function verifySave(string $class, callable $whatToCheck)
+    {
+        $className = $this->getClassName($class);
+        $data = file_get_contents(__DIR__ . "/../../mocks/{$className}/POST_{$className}_Save_RESP.json");
+        $dataArray = json_decode($data, true);
+
+        $this->http->mock
+            ->when()
+            ->methodIs('POST')
+            ->pathIs("/1.1.2/{$className}/Save?apikey=key")
+            ->then()
+            ->body($data)
+            ->end();
+        $this->http->setUp();
+
+        $request = new RequestHandler($this->config);
+
+
+        /**
+         * We make a local client to connect to our mock and get the
+         * expected result
+         */
+        $localClient = new Client();
+
+        $localResult = $localClient->request(
+            'POST',
+            "http://localhost:8082/1.1.2/{$className}/Save?apikey=key",
+            $dataArray
+        );
+
+        /**
+         * We then make a mock client, and tell the mock client that it
+         * should return what the local client got from the mock
+         */
+        $mockClient = \Mockery::mock(
+            'Client'
+        );
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->andReturn($localResult);
+
+        /**
+         * Insert the mocked client into the request class via reflection
+         *
+         * This will pass the desired mock object back to the assertion
+         * as it replaces the legit Client() object
+         */
+        $reflection = new ReflectionClass($request);
+        $reflectedClient = $reflection->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($request, $mockClient);
+
+        $model = new $class($this->config);
+
+        /**
+         * We then reflect into the model
+         */
+        $modelReflection = new ReflectionClass($model);
+        $reflectedRequest = $modelReflection->getProperty('request');
+        $reflectedRequest->setAccessible(true);
+        $reflectedRequest->setValue($model, $request);
+
+        $data = json_decode(file_get_contents(__DIR__ . "/../../mocks/{$className}/POST_{$className}_Save_REQ.json"));
+        $model->loadResult($data);
+
+        $response = $model->save();
+        $whatToCheck($response);
+    }
+
+    public function verifyDelete(string $class, int $id, callable $whatToCheck)
+    {
+        $className = $this->getClassName($class);
+        $this->http->mock
+            ->when()
+            ->methodIs('DELETE')
+            ->pathIs("/1.1.2/{$className}/Delete/{$id}?apikey=key")
+            ->then()
+            ->body(null)
+            ->end();
+        $this->http->setUp();
+
+        $request = new RequestHandler($this->config);
+
+
+        /**
+         * We make a local client to connect to our mock and get the
+         * expected result
+         */
+        $localClient = new Client();
+
+        $localResult = $localClient->request(
+            'DELETE',
+            "http://localhost:8082/1.1.2/{$className}/Delete/{$id}?apikey=key",
+            []
+        );
+
+        /**
+         * We then make a mock client, and tell the mock client that it
+         * should return what the local client got from the mock
+         */
+        $mockClient = \Mockery::mock(
+            'Client'
+        );
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->andReturn($localResult);
+
+        /**
+         * Insert the mocked client into the request class via reflection
+         *
+         * This will pass the desired mock object back to the assertion
+         * as it replaces the legit Client() object
+         */
+        $reflection = new ReflectionClass($request);
+        $reflectedClient = $reflection->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($request, $mockClient);
+
+        $model = new $class($this->config);
+
+        /**
+         * We then reflect into the model
+         */
+        $modelReflection = new ReflectionClass($model);
+        $reflectedRequest = $modelReflection->getProperty('request');
+        $reflectedRequest->setAccessible(true);
+        $reflectedRequest->setValue($model, $request);
+
+        $model->delete($id);
+    }
+}


### PR DESCRIPTION
1. We must setup all fields as protected because magic method __set() is not called for public properties.
    If it is public then this check in __set() method is not called
        if (!$this->fields[$key]['nullable'] && is_null($value))
    So no exception is thrown and user can set not nullable fields to null
    It will not cause any problems because __get() is overwritten too to return protected properties

2. Added basic methods for tests which hide many common configuration calls so tests look much clearer now