### PR TITLE
Added github template for Issues and Pull Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,21 +3,23 @@
 Thanks for submitting an issue! Follow these guidelines to ensure a
 quick resolution to your problem.
 
-Before your submit your issue, please consider whether or not you are
+Before opening an issue, please consider whether or not you are
 able to fork this repository and resolve it yourself. If so it may be
-better to open a PR for the fix (and add yourself as a contributor).
+better to open a Pull Request for the fix (and add yourself as a 
+contributor).
 
 If your issue is a question then this is not the place to submit it.
 You can ask questions about this project on StackOverflow.
 
-Before you open an issue please check to ensure one has not already been
-opened (or closed even), and please include step-by-step reproduction
-instructions.
+Before you open an issue, please check that your issue has not already
+been opened, or maybe even closed.
+
+Remember to include step-by-step reproduction instructions.
 
 Include any and all relevant error messages, codes, line numbers, commit
-hashes, PR numbers, filenames, etc.
+hashes, Pull Request or Issye numbers, filenames, etc.
 
-You must delete everything above (and including) this line.
+You must delete everything above, including this line.
 
 ## Overview
 
@@ -38,10 +40,14 @@ You must delete everything above (and including) this line.
 
 ...
 
-## What steps will reproduce the problem?
+## Which steps would reproduce this problem?
 
 1.
 2.
 3.
+
+## Additional Information
+
+...
 
 Alert the following people: @darrynten 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ been opened, or maybe even closed.
 Remember to include step-by-step reproduction instructions.
 
 Include any and all relevant error messages, codes, line numbers, commit
-hashes, Pull Request or Issye numbers, filenames, etc.
+hashes, Pull Request or Issue numbers, filenames, etc.
 
 You must delete everything above, including this line.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+**DELETE THIS INFORMATION BEFORE SUBMITTING**
+
+Thanks for submitting an issue! Follow these guidelines to ensure a
+quick resolution to your problem.
+
+Before your submit your issue, please consider whether or not you are
+able to fork this repository and resolve it yourself. If so it may be
+better to open a PR for the fix (and add yourself as a contributor).
+
+If your issue is a question then this is not the place to submit it.
+You can ask questions about this project on StackOverflow.
+
+Before you open an issue please check to ensure one has not already been
+opened (or closed even), and please include step-by-step reproduction
+instructions.
+
+Include any and all relevant error messages, codes, line numbers, commit
+hashes, PR numbers, filenames, etc.
+
+You must delete everything above (and including) this line.
+
+## Overview
+
+| Q                    | A
+| -------------------- | ---
+| Bug?                 | yes/no
+| Feature Request?     | yes/no
+| Enhancement?         | yes/no
+| Documentation issue? | yes/no
+| Version?             | 
+| Related issues?      | #
+
+## What happened?
+
+...
+
+## What should have happened?
+
+...
+
+## What steps will reproduce the problem?
+
+1.
+2.
+3.
+
+Alert the following people: @darrynten 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,20 @@
 **DELETE THIS INFORMATION BEFORE SUBMITTING**
 
-Thanks for opening a pull request! Here are some guidelines.
+Thanks for opening a Pull Request! Here are some guidelines.
 
 There are several continuous integration services that will check the
 code you're about to open up, and your code will only be reviewed by
 humans after all the checks are green and there are no issues in the code.
 
 Please ensure you've gone through the following checks before opening your
-PR in order to ensure it is resolved swiftly.
+PR in order to ensure it is resolved quickly and efficiently.
 
 [ ] You're submitting into `dev` branch
 [ ] It contains a single feature
 [ ] Documentation has been updated
 [ ] Full test coverage is in place
 [ ] Manual test steps are documented if required
-[ ] Commits squashed into a meaningful commit meaasage
+[ ] Commits squashed into a meaningful commit message
 [ ] Code style is consistent with project
 [ ] Mocks are included where needed
 
@@ -23,7 +23,7 @@ Please indicate if the PR deals with a bug or a feature in the title.
 If you know who needs to review the code please request a review from them
 when you open the PR.
 
-The template appears below, you must remove this line and the ones above.
+Remove everything above, including this line. The template is below.
 
 ## Overview
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+**DELETE THIS INFORMATION BEFORE SUBMITTING**
+
+Thanks for opening a pull request! Here are some guidelines.
+
+There are several continuous integration services that will check the
+code you're about to open up, and your code will only be reviewed by
+humans after all the checks are green and there are no issues in the code.
+
+Please ensure you've gone through the following checks before opening your
+PR in order to ensure it is resolved swiftly.
+
+[ ] You're submitting into `dev` branch
+[ ] It contains a single feature
+[ ] Documentation has been updated
+[ ] Full test coverage is in place
+[ ] Manual test steps are documented if required
+[ ] Commits squashed into a meaningful commit meaasage
+[ ] Code style is consistent with project
+[ ] Mocks are included where needed
+
+Please indicate if the PR deals with a bug or a feature in the title.
+
+If you know who needs to review the code please request a review from them
+when you open the PR.
+
+The template appears below, you must remove this line and the ones above.
+
+## Overview
+
+| Q                 | A
+| ----------------- | ---
+| Bugfix?           | yes/no
+| New feature?      | yes/no
+| Breaking Changes? | yes/no
+| Fixed issues      | #
+
+## The problem
+
+...
+
+## How I resolved it
+
+...
+
+## How to verify it
+
+...
+
+## Questions
+
+...
+
+## Notes
+
+...
+
+Notify the following people: @darrynten 


### PR DESCRIPTION
I was working together with @make-it-git today and he opened a PR without
a description, so var.ci bot was repeatedly complaining and closing
the issue as invalid.

This wasted quite a bit of time, so I think the solution is to introduce
templates for opening PRs and for reporting issues.

This will help ensure consistent PRs and Issues, and will help keep any
new developers joining the project on the same page.

I'd like to have everyone's input on this before bringing it in.

[These are automatically picked up by github](https://help.github.com/articles/helping-people-contribute-to-your-project)

Thanks! 😎