### PR TITLE
Reordered error codes and added default

### DIFF
--- a/src/Exception/ExceptionMessages.php
+++ b/src/Exception/ExceptionMessages.php
@@ -9,6 +9,15 @@ namespace DarrynTen\SageOne\Exception;
  */
 class ExceptionMessages
 {
+    // Validation codes 100xx
+    public static $validationMessages = [
+        10000 => 'Unknown validation error',
+        10001 => 'Integer value is out of range',
+        10002 => 'String length is out of range',
+        10003 => 'String did not match validation regex',
+        10004 => 'Validation type is invalid',
+    ];
+
     // Model codes 101xx
     public static $modelErrorMessages = [
         // Methods
@@ -27,19 +36,11 @@ class ExceptionMessages
         10116 => 'Attempting to get an undefined property',
     ];
 
-    // Model collection error codes 103xxx
+    // Model collection error codes 102xx
     public static $modelCollectionErrorMessages = [
-        10300 => 'Access to undefined property',
-        10301 => 'Missing required property in object'
-    ];
-
-    // Validation codes 102x
-    public static $validationMessages = [
-        10200 => 'Unknown validation error',
-        10201 => 'Integer value is out of range',
-        10202 => 'String length is out of range',
-        10203 => 'String did not match validation regex',
-        10204 => 'Validation type is invalid',
+        10200 => 'Undefined model collection exception',
+        10201 => 'Attempting to access undefined property',
+        10202 => 'Missing required property in object'
     ];
 
     // Maps to standard HTTP error codes

--- a/src/Exception/ModelCollectionException.php
+++ b/src/Exception/ModelCollectionException.php
@@ -21,16 +21,16 @@ use DarrynTen\SageOne\Exception\ExceptionMessages;
  */
 class ModelCollectionException extends Exception
 {
-    const GETTING_UNDEFINED_PROPERTY = 10300;
-    const MISSING_REQUIRED_PROPERTY = 10301;
+    const GETTING_UNDEFINED_PROPERTY = 10201;
+    const MISSING_REQUIRED_PROPERTY = 10202;
 
     /**
      * Custom Model collection exception handler
      *
-     * @var integer $code The error code
+     * @var integer $code The error code [10200 is default]
      * @var string $extra Any additional information to be included
      */
-    public function __construct($code, $extra = '')
+    public function __construct($code = 10200, $extra = '')
     {
         $message = sprintf(
             'ModelCollection %s %s',

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -21,10 +21,10 @@ use DarrynTen\SageOne\Exception\ExceptionMessages;
  */
 class ValidationException extends Exception
 {
-    const INTEGER_OUT_OF_RANGE = 10201;
-    const STRING_LENGTH_OUT_OF_RANGE = 10202;
-    const STRING_REGEX_MISMATCH = 10203;
-    const VALIDATION_TYPE_ERROR = 10204;
+    const INTEGER_OUT_OF_RANGE = 10001;
+    const STRING_LENGTH_OUT_OF_RANGE = 10002;
+    const STRING_REGEX_MISMATCH = 10003;
+    const VALIDATION_TYPE_ERROR = 10004;
 
     /**
      * Custom Model exception handler
@@ -33,7 +33,7 @@ class ValidationException extends Exception
      * @var integer $code The error code (as per above) [10200 is Generic code]
      * @var string $extra Any additional information to be included
      */
-    public function __construct($code = 10200, $extra = '')
+    public function __construct($code = 10000, $extra = '')
     {
         $message = sprintf(
             'Validation error %s %s',

--- a/tests/SageOne/Models/ExampleModelTest.php
+++ b/tests/SageOne/Models/ExampleModelTest.php
@@ -182,7 +182,7 @@ class ExampleModelTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Validation error value -1 out of min(1) max(2147483647) Integer value is out of range');
-        $this->expectExceptionCode(10201);
+        $this->expectExceptionCode(10001);
 
         $exampleModel = new Example($this->config);
 
@@ -194,7 +194,7 @@ class ExampleModelTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Validation error value This string is too long! out of min(1) max(10) String length is out of range');
-        $this->expectExceptionCode(10202);
+        $this->expectExceptionCode(10002);
 
         $exampleModel = new Example($this->config);
 
@@ -206,7 +206,7 @@ class ExampleModelTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Validation error value  is type NULL Validation type is invalid');
-        $this->expectExceptionCode(10204);
+        $this->expectExceptionCode(10004);
 
         $exampleModel = new Example($this->config);
 
@@ -218,7 +218,7 @@ class ExampleModelTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Validation error value bademail failed to validate String did not match validation regex');
-        $this->expectExceptionCode(10203);
+        $this->expectExceptionCode(10003);
 
         $exampleModel = new Example($this->config);
 

--- a/tests/SageOne/Models/ModelCollectionTest.php
+++ b/tests/SageOne/Models/ModelCollectionTest.php
@@ -13,8 +13,8 @@ class ModelCollectionTest extends BaseModelTest
     public function testException()
     {
         $this->expectException(ModelCollectionException::class);
-        $this->expectExceptionMessage('ModelCollection Access to undefined property undefinedProperty');
-        $this->expectExceptionCode(10300);
+        $this->expectExceptionMessage('ModelCollection Attempting to access undefined property undefinedProperty');
+        $this->expectExceptionCode(10201);
 
         $results = new \stdClass;
         $results->TotalResults = 0;
@@ -28,7 +28,7 @@ class ModelCollectionTest extends BaseModelTest
     {
         $this->expectException(ModelCollectionException::class);
         $this->expectExceptionMessage('Missing required property in object TotalResults');
-        $this->expectExceptionCode(10301);
+        $this->expectExceptionCode(10202);
 
         $results = new \stdClass;
         $collection = new ModelCollection(Example::class, $this->config, $results);
@@ -38,7 +38,7 @@ class ModelCollectionTest extends BaseModelTest
     {
         $this->expectException(ModelCollectionException::class);
         $this->expectExceptionMessage('Missing required property in object ReturnedResults');
-        $this->expectExceptionCode(10301);
+        $this->expectExceptionCode(10202);
 
         $results = new \stdClass;
         $results->TotalResults = 1;
@@ -49,7 +49,7 @@ class ModelCollectionTest extends BaseModelTest
     {
         $this->expectException(ModelCollectionException::class);
         $this->expectExceptionMessage('Missing required property in object Results');
-        $this->expectExceptionCode(10301);
+        $this->expectExceptionCode(10202);
 
         $results = new \stdClass;
         $results->TotalResults = 1;


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | no
| New feature?      | no
| Breaking Changes? | no
| Refactor?  | yes
| Fixed issues      | #

## The problem

The error codes were not following a logical order

## How I resolved it

I re-ordered the messages and updated the tests