### PR TITLE
Get all models

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Models marked with an asterix are pure CRUD models
 - [x] CRUD
 - [ ] Save Call
 - [ ] Real CRUD Response Mocks
-- [ ] Pagination
+- [x] Pagination
 - [ ] Rate Limiting
 - [ ] Models
   - [x] Account

--- a/src/Models/ModelCollection.php
+++ b/src/Models/ModelCollection.php
@@ -101,4 +101,10 @@ class ModelCollection
         $this->returnedResults = $collectionObject->ReturnedResults;
         $this->results = $models;
     }
+
+    public function extend(ModelCollection $otherCollection)
+    {
+        $this->returnedResults += $otherCollection->returnedResults;
+        $this->results = array_merge($this->results, $otherCollection->results);
+    }
 }

--- a/src/Models/SimpleExample.php
+++ b/src/Models/SimpleExample.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * SageOne Library
+ *
+ * @category Library
+ * @package  SageOne
+ * @author   Vitaliy Likhachev <make.it.git@gmail.com>
+ * @license  MIT <https://github.com/darrynten/sage-one-php/blob/master/LICENSE>
+ * @link     https://github.com/darrynten/sage-one-php
+ */
+
+namespace DarrynTen\SageOne\Models;
+
+use DarrynTen\SageOne\BaseModel;
+
+/**
+ * Simple Example Model
+ * This model is used in tests when we do not care about it's contents
+ * and want to test not fields, but model itself
+ */
+class SimpleExample extends BaseModel
+{
+    /**
+     * @var string $endpoint
+     */
+    protected $endpoint = 'SimpleExample';
+
+    /**
+     * @var array $fields
+     */
+    protected $fields = [
+        'id' => [
+            'type' => 'integer',
+            'nullable' => false,
+            'readonly' => false,
+        ],
+    ];
+
+    /**
+     * @var array $features
+     */
+    protected $features = [
+        'all' => true,
+        'get' => true,
+        'save' => true,
+        'delete' => true,
+    ];
+}

--- a/tests/SageOne/Models/ModelCollectionTest.php
+++ b/tests/SageOne/Models/ModelCollectionTest.php
@@ -9,6 +9,9 @@ use DarrynTen\SageOne\Exception\ModelException;
 use DarrynTen\SageOne\Models\ModelCollection;
 use DarrynTen\SageOne\Models\Example;
 use DarrynTen\SageOne\Models\ExampleCategory;
+use DarrynTen\SageOne\Models\SimpleExample;
+use DarrynTen\SageOne\Request\RequestHandler;
+use GuzzleHttp\Client;
 
 class ModelCollectionTest extends BaseModelTest
 {
@@ -159,5 +162,191 @@ class ModelCollectionTest extends BaseModelTest
         $this->expectExceptionCode(10117);
 
         $exampleModel->toJson();
+    }
+
+    public function testCollectionExtend()
+    {
+        $obj1 = new \stdClass;
+        $obj1->ID = 10;
+        $obj2 = new \stdClass;
+        $obj2->ID = 20;
+        $obj3 = new \stdClass;
+        $obj3->ID = 30;
+
+        $results = new \stdClass;
+        $results->TotalResults = 3;
+        $results->ReturnedResults = 1;
+        $results->Results = [$obj1];
+
+        $collection = new ModelCollection(SimpleExample::class, $this->config, $results);
+
+        $this->assertEquals(3, $collection->totalResults);
+        $this->assertEquals(1, $collection->returnedResults);
+        $this->assertCount(1, $collection->results);
+
+        $results = new \stdClass;
+        $results->TotalResults = 3;
+        $results->ReturnedResults = 2;
+        $results->Results = [$obj2, $obj3];
+        $otherCollection = new ModelCollection(SimpleExample::class, $this->config, $results);
+
+        $collection->extend($otherCollection);
+        $this->assertEquals(3, $collection->totalResults);
+        $this->assertEquals(3, $collection->returnedResults);
+        $this->assertCount(3, $collection->results);
+        $this->assertEquals(10, $collection->results[0]->id);
+        $this->assertEquals(20, $collection->results[1]->id);
+        $this->assertEquals(30, $collection->results[2]->id);
+    }
+
+    public function testCollectionGetAllMany()
+    {
+        $apikey = urlencode('{key}');
+        $path = 'SimpleExample/Get';
+        $url1 = sprintf('/1.1.2/%s?apikey=%s', $path, $apikey);
+        $url2 = sprintf('/1.1.2/%s?$skip=100apikey=%s', $path, $apikey);
+        $url3 = sprintf('/1.1.2/%s?$skip=200=%s', $path, $apikey);
+
+        $response1 = [
+            'TotalResults' => 204,
+            'ReturnedResults' => 100,
+            'Results' => []
+        ];
+        $response2 = [
+            'TotalResults' => 204,
+            'ReturnedResults' => 100,
+            'Results' => []
+        ];
+        $response3 = [
+            'TotalResults' => 204,
+            'ReturnedResults' => 4,
+            'Results' => []
+        ];
+
+        for ($i = 1; $i <= 100; $i++) {
+            $response1['Results'][] = [
+                'ID' => $i
+            ];
+        }
+
+        for ($i = 101; $i <= 200; $i++) {
+            $response2['Results'][] = [
+                'ID' => $i
+            ];
+        }
+
+        for ($i = 201; $i <= 204; $i++) {
+            $response3['Results'][] = [
+                'ID' => $i
+            ];
+        }
+
+        $response1 = json_encode($response1);
+        $response2 = json_encode($response2);
+        $response3 = json_encode($response3);
+
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs($url1)
+            ->then()
+            ->body($response1)
+            ->end();
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs($url2)
+            ->then()
+            ->body($response2)
+            ->end();
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs($url3)
+            ->then()
+            ->body($response3)
+            ->end();
+        $this->http->setUp();
+
+        $request = new RequestHandler($this->config);
+
+        $localClient = new Client();
+        $localResult1 = $localClient->request(
+            'GET',
+            '//localhost:8082' . $url1
+        );
+        $localResult2 = $localClient->request(
+            'GET',
+            '//localhost:8082' . $url2
+        );
+        $localResult3 = $localClient->request(
+            'GET',
+            '//localhost:8082' . $url3
+        );
+
+        $mockClient = \Mockery::mock(
+            'Client'
+        );
+
+        $params1 = [
+            'query' => [
+                'apikey' => $apikey
+            ],
+            'headers' => [
+                'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
+            ],
+        ];
+        $params2 = [
+            'query' => [
+                'apikey' => $apikey,
+                '$skip' => '100'
+            ],
+            'headers' => [
+                'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
+            ],
+        ];
+        $params3 = [
+            'query' => [
+                'apikey' => $apikey,
+                '$skip' => '200'
+            ],
+            'headers' => [
+                'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='
+            ],
+        ];
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('GET', '//localhost:8082/1.1.2/SimpleExample/Get/', $params1)
+            ->andReturn($localResult1);
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('GET', '//localhost:8082/1.1.2/SimpleExample/Get/', $params2)
+            ->andReturn($localResult2);
+
+        $mockClient->shouldReceive('request')
+            ->once()
+            ->with('GET', '//localhost:8082/1.1.2/SimpleExample/Get/', $params3)
+            ->andReturn($localResult3);
+
+        $reflection = new ReflectionClass($request);
+        $reflectedClient = $reflection->getProperty('client');
+        $reflectedClient->setAccessible(true);
+        $reflectedClient->setValue($request, $mockClient);
+
+        $model = new SimpleExample($this->config);
+
+        $modelReflection = new ReflectionClass($model);
+        $reflectedRequest = $modelReflection->getProperty('request');
+        $reflectedRequest->setAccessible(true);
+        $reflectedRequest->setValue($model, $request);
+
+        $response = $model->all();
+
+        $this->assertInstanceOf(ModelCollection::class, $response);
+        $this->assertEquals(204, $response->totalResults);
+        $this->assertEquals(204, $response->returnedResults);
+        $this->assertCount(204, $response->results);
     }
 }

--- a/tests/mocks/AccountantTaskRecurrence/GET_AccountantTaskRecurrence_Get.json
+++ b/tests/mocks/AccountantTaskRecurrence/GET_AccountantTaskRecurrence_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/AdditionalItemPrice/GET_AdditionalItemPrice_Get.json
+++ b/tests/mocks/AdditionalItemPrice/GET_AdditionalItemPrice_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/AnalysisCategory/GET_AnalysisCategory_Get.json
+++ b/tests/mocks/AnalysisCategory/GET_AnalysisCategory_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/AnalysisType/GET_AnalysisType_Get.json
+++ b/tests/mocks/AnalysisType/GET_AnalysisType_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/AssetNote/GET_AssetNote_Get.json
+++ b/tests/mocks/AssetNote/GET_AssetNote_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/CompanyEntityType/GET_CompanyEntityType_Get.json
+++ b/tests/mocks/CompanyEntityType/GET_CompanyEntityType_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/CompanyNote/GET_CompanyNote_Get.json
+++ b/tests/mocks/CompanyNote/GET_CompanyNote_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/DateFormat/GET_DateFormat_Get.json
+++ b/tests/mocks/DateFormat/GET_DateFormat_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/SupplierAdditionalContactDetail/GET_SupplierAdditionalContactDetail_Get.json
+++ b/tests/mocks/SupplierAdditionalContactDetail/GET_SupplierAdditionalContactDetail_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 4,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/SupplierAdjustment/GET_SupplierAdjustment_Get.json
+++ b/tests/mocks/SupplierAdjustment/GET_SupplierAdjustment_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/SupplierBankDetail/GET_SupplierBankDetail_Get.json
+++ b/tests/mocks/SupplierBankDetail/GET_SupplierBankDetail_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/SupplierNote/GET_SupplierNote_Get.json
+++ b/tests/mocks/SupplierNote/GET_SupplierNote_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {

--- a/tests/mocks/SupplierOpeningBalance/GET_SupplierOpeningBalance_Get.json
+++ b/tests/mocks/SupplierOpeningBalance/GET_SupplierOpeningBalance_Get.json
@@ -1,5 +1,5 @@
 {
-  "TotalResults": 3,
+  "TotalResults": 2,
   "ReturnedResults": 2,
   "Results": [
     {


### PR DESCRIPTION
## Overview

| Q                 | A
| ----------------- | ---
| Bugfix?           | no
| New feature?      | yes
| Breaking Changes? | yes
| Fixed issues      | #

## The problem

all() method did not get all models (only first page of paginated response)

## How I resolved it

We check TotalResults and if it is bigger than ReturnedResults then we try to receive all other pages

Notify the following people: @darrynten 
